### PR TITLE
feat: add onFail and onSuccess template options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,21 +75,21 @@ The `SLACK_WEBHOOK` variable has to be defined in the environment where you will
 
 ### Options
 
-| Option            | Description                                                                                                                   | Default   |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `notifyOnSuccess` | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false     |
-| `notifyOnFail`    | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false     |
-| `onSuccess`       | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined |
-| `onFail`          | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined |
+| Option              | Description                                                                                                                   | Default   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `notifyOnSuccess`   | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false     |
+| `notifyOnFail`      | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false     |
+| `onSuccessTemplate` | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined |
+| `onFailTemplate`    | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined |
 
 ### Templating
 
-If a template is provided via either the `onSuccess` or `onFail` options, it will be used for the respective slack message. The template should be an object that follows the [Slack API message structure](https://api.slack.com/docs/message-formatting). Strings within the template will have keywords replaced:
+If a template is provided via either the `onSuccessTemplate` or `onFailTemplate` options, it will be used for the respective slack message. The template should be an object that follows the [Slack API message structure](https://api.slack.com/docs/message-formatting). Strings within the template will have keywords replaced:
 
-| Keyword                | Description                 | Example                                           | Template  |
-| ---------------------- | --------------------------- | ------------------------------------------------- | --------- |
-| `$npm_package_name`    | The name of the package.    | semantic-release-test                             | Both      |
-| `$npm_package_version` | The version of the release. | 1.0.93                                            | onSuccess |
-| `$repo_path`           | The repository path.        | juliuscc/semantic-release-test                    | Both      |
-| `$repo_url`            | The repository URL.         | https://github.com/juliuscc/semantic-release-test | Both      |
-| `$release_notes`       | The notes of the release.   |                                                   | onSuccess |
+| Keyword                | Description                 | Example                                           | Template          |
+| ---------------------- | --------------------------- | ------------------------------------------------- | ----------------- |
+| `$npm_package_name`    | The name of the package.    | semantic-release-test                             | Both              |
+| `$npm_package_version` | The version of the release. | 1.0.93                                            | onSuccessTemplate |
+| `$repo_path`           | The repository path.        | juliuscc/semantic-release-test                    | Both              |
+| `$repo_url`            | The repository URL.         | https://github.com/juliuscc/semantic-release-test | Both              |
+| `$release_notes`       | The notes of the release.   |                                                   | onSuccessTemplate |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,21 @@ The `SLACK_WEBHOOK` variable has to be defined in the environment where you will
 
 ### Options
 
-| Option            | Description                                                                                                                   | Default |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `notifyOnSuccess` | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false   |
-| `notifyOnFail`    | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false   |
+| Option            | Description                                                                                                                   | Default   |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `notifyOnSuccess` | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false     |
+| `notifyOnFail`    | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false     |
+| `onSuccess`       | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined |
+| `onFail`          | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined |
+
+### Templating
+
+If a template is provided via either the `onSuccess` or `onFail` options, it will be used for the respective slack message. The template should be an object that follows the [Slack API message structure](https://api.slack.com/docs/message-formatting). Strings within the template will have keywords replaced:
+
+| Keyword                | Description                 | Example                                           | Template  |
+| ---------------------- | --------------------------- | ------------------------------------------------- | --------- |
+| `$npm_package_name`    | The name of the package.    | semantic-release-test                             | Both      |
+| `$npm_package_version` | The version of the release. | 1.0.93                                            | onSuccess |
+| `$repo_path`           | The repository path.        | juliuscc/semantic-release-test                    | Both      |
+| `$repo_url`            | The repository URL.         | https://github.com/juliuscc/semantic-release-test | Both      |
+| `$release_notes`       | The notes of the release.   |                                                   | onSuccess |

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -20,8 +20,8 @@ module.exports = async (pluginConfig, context) => {
 			: undefined
 	const repoURL = repoPath && `https://github.com/${repoPath}`
 
-	if (pluginConfig.onFail) {
-		slackMessage = template(pluginConfig.onFail, {
+	if (pluginConfig.onFailTemplate) {
+		slackMessage = template(pluginConfig.onFailTemplate, {
 			npm_package_name,
 			repo_path: repoPath,
 			repo_url: repoURL

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -18,11 +18,13 @@ module.exports = async (pluginConfig, context) => {
 		options.repositoryUrl.indexOf('git@github.com') !== -1
 			? options.repositoryUrl.split(':')[1].replace('.git', '')
 			: undefined
+	const repoURL = repoPath && `https://github.com/${repoPath}`
 
 	if (pluginConfig.onFail) {
 		slackMessage = template(pluginConfig.onFail, {
 			npm_package_name,
-			github_path: repoPath
+			repo_path: repoPath,
+			repo_url: repoURL
 		})
 	} else {
 		const plural = errors.length > 1
@@ -46,8 +48,6 @@ module.exports = async (pluginConfig, context) => {
 		]
 
 		if (repoPath) {
-			const repoURL = `https://github.com/${repoPath}`
-
 			const metadata = {
 				type: 'context',
 				elements: [

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 const postMessage = require('./postMessage')
+const template = require('./template')
 
 module.exports = async (pluginConfig, context) => {
 	const { logger, options, errors } = context
@@ -12,79 +13,91 @@ module.exports = async (pluginConfig, context) => {
 
 	logger.log('Sending slack notification on fail')
 
-	const plural = errors.length > 1
+	let slackMessage = {}
+	const repoPath =
+		options.repositoryUrl.indexOf('git@github.com') !== -1
+			? options.repositoryUrl.split(':')[1].replace('.git', '')
+			: undefined
 
-	const messageSummaryLine = `${
-		plural ? 'Errors' : 'An error'
-	} occurred while trying to publish the new version of \`${npm_package_name}\`!`
+	if (pluginConfig.onFail) {
+		slackMessage = template(pluginConfig.onFail, {
+			npm_package_name,
+			github_path: repoPath
+		})
+	} else {
+		const plural = errors.length > 1
 
-	const divider = {
-		type: 'divider'
-	}
+		const messageSummaryLine = `${
+			plural ? 'Errors' : 'An error'
+		} occurred while trying to publish the new version of \`${npm_package_name}\`!`
 
-	let messageBlocks = [
-		{
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: messageSummaryLine
-			}
+		const divider = {
+			type: 'divider'
 		}
-	]
 
-	if (options.repositoryUrl.indexOf('git@github.com') !== -1) {
-		const repoPath = options.repositoryUrl.split(':')[1].replace('.git', '')
-		const repoURL = `https://github.com/${repoPath}`
-
-		const metadata = {
-			type: 'context',
-			elements: [
-				{
+		let messageBlocks = [
+			{
+				type: 'section',
+				text: {
 					type: 'mrkdwn',
-					text: `*<${repoURL}|${repoPath}>*`
+					text: messageSummaryLine
+				}
+			}
+		]
+
+		if (repoPath) {
+			const repoURL = `https://github.com/${repoPath}`
+
+			const metadata = {
+				type: 'context',
+				elements: [
+					{
+						type: 'mrkdwn',
+						text: `*<${repoURL}|${repoPath}>*`
+					}
+				]
+			}
+
+			messageBlocks.push(metadata)
+		}
+
+		// messageBlocks.push(divider)
+
+		const attachments = [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `:no_entry:  *${plural ? 'Exceptions' : 'Exception'}*`
+				}
+			}
+		]
+
+		for (const error of errors) {
+			if (attachments.length > 2) {
+				attachments.push(divider)
+			}
+			attachments.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `\`\`\`${error.stack}\`\`\``
+				}
+			})
+		}
+
+		slackMessage = {
+			text: `${
+				plural ? 'Errors' : 'An error'
+			} occurred while trying to publish the new version of ${npm_package_name}!`,
+			blocks: messageBlocks,
+			attachments: [
+				{
+					color: '#ff0000',
+					blocks: attachments
 				}
 			]
 		}
-
-		messageBlocks.push(metadata)
-	}
-
-	// messageBlocks.push(divider)
-
-	const attachments = [
-		{
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: `:no_entry:  *${plural ? 'Exceptions' : 'Exception'}*`
-			}
-		}
-	]
-
-	for (const error of errors) {
-		if (attachments.length > 2) {
-			attachments.push(divider)
-		}
-		attachments.push({
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: `\`\`\`${error.stack}\`\`\``
-			}
-		})
-	}
-
-	let slackMessage = {
-		text: `${
-			plural ? 'Errors' : 'An error'
-		} occurred while trying to publish the new version of ${npm_package_name}!`,
-		blocks: messageBlocks,
-		attachments: [
-			{
-				color: '#ff0000',
-				blocks: attachments
-			}
-		]
 	}
 
 	await postMessage(slackMessage, logger)

--- a/lib/success.js
+++ b/lib/success.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 const postMessage = require('./postMessage')
+const template = require('./template')
 
 module.exports = async (pluginConfig, context) => {
 	const { logger, nextRelease, options } = context
@@ -12,54 +13,68 @@ module.exports = async (pluginConfig, context) => {
 
 	logger.log('Sending slack notification on success')
 
-	let messageBlocks = [
-		{
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: `A new version of \`${npm_package_name}\` has been released!\nCurrent version is *#${
-					nextRelease.version
-				}*`
-			}
-		}
-	]
+	let slackMessage = {}
+	const repoPath =
+		options.repositoryUrl.indexOf('git@github.com') !== -1
+			? options.repositoryUrl.split(':')[1].replace('.git', '')
+			: undefined
 
-	if (nextRelease.notes !== '') {
-		messageBlocks.push({
-			type: 'section',
-			text: {
-				type: 'mrkdwn',
-				text: `*Notes*: ${nextRelease.notes}`
-			}
+	if (pluginConfig.onSuccess) {
+		slackMessage = template(pluginConfig.onSuccess, {
+			npm_package_name,
+			npm_package_version: nextRelease.version,
+			github_path: repoPath,
+			release_notes: nextRelease.notes
 		})
-	}
-
-	let slackMessage = {
-		blocks: messageBlocks,
-		text: `A new version of ${npm_package_name} has been released!`
-	}
-
-	if (options.repositoryUrl.indexOf('git@github.com') !== -1) {
-		const repoPath = options.repositoryUrl.split(':')[1].replace('.git', '')
-		const repoURL = `https://github.com/${repoPath}`
-		const gitTag = nextRelease.gitTag
-
-		slackMessage.attachments = [
+	} else {
+		let messageBlocks = [
 			{
-				color: '#2cbe4e',
-				blocks: [
-					{
-						type: 'context',
-						elements: [
-							{
-								type: 'mrkdwn',
-								text: `:package: *<${repoURL}|${repoPath}>:*   <${repoURL}/releases/tag/${gitTag}|${gitTag}>`
-							}
-						]
-					}
-				]
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `A new version of \`${npm_package_name}\` has been released!\nCurrent version is *#${
+						nextRelease.version
+					}*`
+				}
 			}
 		]
+
+		if (nextRelease.notes !== '') {
+			messageBlocks.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `*Notes*: ${nextRelease.notes}`
+				}
+			})
+		}
+
+		slackMessage = {
+			blocks: messageBlocks,
+			text: `A new version of ${npm_package_name} has been released!`
+		}
+
+		if (repoPath) {
+			const repoURL = `https://github.com/${repoPath}`
+			const gitTag = nextRelease.gitTag
+
+			slackMessage.attachments = [
+				{
+					color: '#2cbe4e',
+					blocks: [
+						{
+							type: 'context',
+							elements: [
+								{
+									type: 'mrkdwn',
+									text: `:package: *<${repoURL}|${repoPath}>:*   <${repoURL}/releases/tag/${gitTag}|${gitTag}>`
+								}
+							]
+						}
+					]
+				}
+			]
+		}
 	}
 
 	await postMessage(slackMessage, logger)

--- a/lib/success.js
+++ b/lib/success.js
@@ -20,8 +20,8 @@ module.exports = async (pluginConfig, context) => {
 			: undefined
 	const repoURL = repoPath && `https://github.com/${repoPath}`
 
-	if (pluginConfig.onSuccess) {
-		slackMessage = template(pluginConfig.onSuccess, {
+	if (pluginConfig.onSuccessTemplate) {
+		slackMessage = template(pluginConfig.onSuccessTemplate, {
 			npm_package_name,
 			npm_package_version: nextRelease.version,
 			repo_path: repoPath,

--- a/lib/success.js
+++ b/lib/success.js
@@ -18,12 +18,14 @@ module.exports = async (pluginConfig, context) => {
 		options.repositoryUrl.indexOf('git@github.com') !== -1
 			? options.repositoryUrl.split(':')[1].replace('.git', '')
 			: undefined
+	const repoURL = repoPath && `https://github.com/${repoPath}`
 
 	if (pluginConfig.onSuccess) {
 		slackMessage = template(pluginConfig.onSuccess, {
 			npm_package_name,
 			npm_package_version: nextRelease.version,
-			github_path: repoPath,
+			repo_path: repoPath,
+			repo_URL: repoURL,
 			release_notes: nextRelease.notes
 		})
 	} else {
@@ -55,7 +57,6 @@ module.exports = async (pluginConfig, context) => {
 		}
 
 		if (repoPath) {
-			const repoURL = `https://github.com/${repoPath}`
 			const gitTag = nextRelease.gitTag
 
 			slackMessage.attachments = [

--- a/lib/success.js
+++ b/lib/success.js
@@ -25,7 +25,7 @@ module.exports = async (pluginConfig, context) => {
 			npm_package_name,
 			npm_package_version: nextRelease.version,
 			repo_path: repoPath,
-			repo_URL: repoURL,
+			repo_url: repoURL,
 			release_notes: nextRelease.notes
 		})
 	} else {

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,0 +1,31 @@
+function template(input, variables) {
+	const type = typeof input
+	if (type === 'string') {
+		return Object.keys(variables).reduce(
+			(output, variable) =>
+				variables[variable]
+					? output.replace(`$${variable}`, variables[variable])
+					: output,
+			input
+		)
+	} else if (type === 'object') {
+		if (Array.isArray(input)) {
+			const out = []
+			for (const value of input) {
+				out.push(template(value, variables))
+			}
+			return out
+		} else {
+			const out = {}
+			for (let key of Object.keys(input)) {
+				const value = input[key]
+				out[key] = template(value, variables)
+			}
+			return out
+		}
+	} else {
+		return input
+	}
+}
+
+module.exports = template


### PR DESCRIPTION
Proof of concept of slack message customisation. Essentially a user would provide a template slack message object to either the `onFailTemplate` or `onSuccessTemplate` config options, they will then be used when sending the message and the following keywords would be replaced:
* **onSuccessTemplate**
  * `npm_package_name`
  * `npm_package_version`
  * `github_path`
  * `release_notes`
* **onFailTemplate**
  * `npm_package_name`
  * `github_path`

I haven't added any documentation yet, because I wanted to get some thoughts on the idea @juliuscc 

fixes: #2 