### PR TITLE
fix: truncated release notes > 3000 chars

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -2,14 +2,8 @@
 const postMessage = require('./postMessage')
 const template = require('./template')
 
-/*
- * Regarding to https://api.slack.com/reference/messaging/blocks#section
- * the max length of texts is 3000
- * If it is set to 3000 the post is failing. I guess it is because the
- * complete length of the message_block.text (containing also the JSON)
- * is used to calculating the length.
- */
-const MAX_LENGTH = 2950
+// Max lenght of message to the slack api is 3000 characters. Make sure we are below that.
+const MAX_LENGTH = 2900
 
 module.exports = async (pluginConfig, context) => {
 	const { logger, nextRelease, options } = context
@@ -56,11 +50,16 @@ module.exports = async (pluginConfig, context) => {
 		]
 
 		if (nextRelease.notes !== '') {
+			// truncate long messages
+			let messageText = 
+			    nextRelease.notes.length > MAX_LENGTH 
+			    	? nextRelease.notes.substring(0, MAX_LENGTH) + '*[...]*' 
+				: nextRelease.notes
 			messageBlocks.push({
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `*Notes*: ${nextRelease.notes.substring(0, MAX_LENGTH)}`
+					text: `*Notes*: ${messageText}`
 				}
 			})
 		}

--- a/lib/success.js
+++ b/lib/success.js
@@ -2,6 +2,15 @@
 const postMessage = require('./postMessage')
 const template = require('./template')
 
+/*
+ * Regarding to https://api.slack.com/reference/messaging/blocks#section
+ * the max length of texts is 3000
+ * If it is set to 3000 the post is failing. I guess it is because the
+ * complete length of the message_block.text (containing also the JSON)
+ * is used to calculating the length.
+ */
+const MAX_LENGTH = 2950
+
 module.exports = async (pluginConfig, context) => {
 	const { logger, nextRelease, options } = context
 
@@ -51,7 +60,7 @@ module.exports = async (pluginConfig, context) => {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `*Notes*: ${nextRelease.notes}`
+					text: `*Notes*: ${nextRelease.notes.substring(0, MAX_LENGTH)}`
 				}
 			})
 		}


### PR DESCRIPTION
The message length of a slack post can only be < 3000 chars.
https://api.slack.com/reference/messaging/blocks#section

I added a truncate into the success hook.