### PR TITLE
feat: add slackWebhook as configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Installing the app will yield you with a webhook that the app uses to publish up
 
 ### Environment variables
 
-The `SLACK_WEBHOOK` variable has to be defined in the environment where you will be running semantic release. This can be done by exporting it in bash or in the user interface of you CI provider. Obtain this token by installing the slack app according to [slack app installation](#slack-app-installation).
+The `SLACK_WEBHOOK` variable can be defined in the environment where you will be running semantic release. This can be done by exporting it in bash or in the user interface of your CI provider. Obtain this token by installing the slack app according to [slack app installation](#slack-app-installation).
+
+Alternatively, you could pass the webhook as a configuration option.
 
 | Variable                   | Description                                              |
 | -------------------------- | -------------------------------------------------------- |
@@ -78,13 +80,14 @@ The `SLACK_WEBHOOK` variable has to be defined in the environment where you will
 
 ### Options
 
-| Option                 | Description                                                                                                                   | Default   |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false     |
-| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false     |
-| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined |
-| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined |
-| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                      | false     |
+| Option                 | Description                                                                                                                   | Default       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false         |
+| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false         |
+| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined     |
+| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined     |
+| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                      | false         |
+| `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                           | SLACK_WEBHOOK |
 
 ### Templating
 

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -5,6 +5,7 @@ const template = require('./template')
 module.exports = async (pluginConfig, context) => {
 	const { logger, options, errors } = context
 	const { npm_package_name } = context.env
+	const { slackWebhook = process.env.SLACK_WEBHOOK } = pluginConfig
 
 	let package_name = context.env.SEMANTIC_RELEASE_PACKAGE
 	if (!package_name) package_name = context.env.npm_package_name
@@ -104,5 +105,5 @@ module.exports = async (pluginConfig, context) => {
 		}
 	}
 
-	await postMessage(slackMessage, logger)
+	await postMessage(slackMessage, logger, slackWebhook)
 }

--- a/lib/postMessage.js
+++ b/lib/postMessage.js
@@ -1,10 +1,8 @@
 const fetch = require('node-fetch')
 const SemanticReleaseError = require('@semantic-release/error')
 
-const slackHook = process.env.SLACK_WEBHOOK
-
-async function postMessage(message, logger) {
-	await fetch(slackHook, {
+async function postMessage(message, logger, slackWebhook) {
+	await fetch(slackWebhook, {
 		method: 'post',
 		headers: {
 			'Content-Type': 'application/json'

--- a/lib/success.js
+++ b/lib/success.js
@@ -8,6 +8,7 @@ const MAX_LENGTH = 2900
 
 module.exports = async (pluginConfig, context) => {
 	const { logger, nextRelease, options } = context
+	const { slackWebhook = process.env.SLACK_WEBHOOK } = pluginConfig
 
 	let package_name = context.env.SEMANTIC_RELEASE_PACKAGE
 	if (!package_name) package_name = context.env.npm_package_name
@@ -102,5 +103,5 @@ module.exports = async (pluginConfig, context) => {
 
 	logger.log(slackMessage)
 
-	await postMessage(slackMessage, logger)
+	await postMessage(slackMessage, logger, slackWebhook)
 }

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -2,15 +2,14 @@ const SemanticReleaseError = require('@semantic-release/error')
 
 module.exports = (pluginConfig, context) => {
 	const { logger } = context
+	const { slackWebhook = process.env.SLACK_WEBHOOK } = pluginConfig
 
-	const slackHook = process.env.SLACK_WEBHOOK
-
-	if (!slackHook) {
+	if (!slackWebhook) {
 		logger.log('SLACK_WEBHOOK has not been defined.')
 		throw new SemanticReleaseError(
 			'No Slack web-hook defined.',
 			'ENOSLACKHOOK',
-			`A Slack Webhook must be created and set in the \`SLACK_WEBHOOK\` environment variable on your CI environment.\n\n\nPlease make sure to create a Slack Webhook and to set it in the \`SLACK_WEBHOOK\` environment variable on your CI environment.`
+			`A Slack Webhook must be created and set in the \`SLACK_WEBHOOK\` environment variable on your CI environment.\n\n\nPlease make sure to create a Slack Webhook and to set it in the \`SLACK_WEBHOOK\` environment variable on your CI environment. Alternatively, provide \`slackWebhook\` as a configuration option.`
 		)
 	}
 


### PR DESCRIPTION
This adds slackWebhook as a configuration option with the default value being the already existing SLACK_WEBHOOK environment variable.

With this, people will be able to provide a slack webhook for this plugin and only for this plugin, without exposing the webhook through the environment to any other plugin or program.

Closes #16