### PR TITLE
fix: Avoid truncating in the middle of markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
       - run:
           name: Lint test
           command: npm run lint
+      - run:
+          name: Run tests
+          command: npm test
   deploy:
     docker:
       - image: circleci/node:10.5.0

--- a/lib/success.js
+++ b/lib/success.js
@@ -2,6 +2,7 @@
 const slackifyMarkdown = require('slackify-markdown')
 const postMessage = require('./postMessage')
 const template = require('./template')
+const truncate = require('./truncate')
 
 // Max lenght of message to the slack api is 3000 characters. Make sure we are below that.
 const MAX_LENGTH = 2900
@@ -57,10 +58,7 @@ module.exports = async (pluginConfig, context) => {
 
 		if (nextRelease.notes !== '') {
 			// truncate long messages
-			let messageText =
-				nextRelease.notes.length > MAX_LENGTH
-					? nextRelease.notes.substring(0, MAX_LENGTH) + '*[...]*'
-					: nextRelease.notes
+			let messageText = truncate(nextRelease.notes, MAX_LENGTH)
 
 			if (pluginConfig.markdownReleaseNotes)
 				messageText = slackifyMarkdown(messageText)

--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -1,0 +1,14 @@
+module.exports = (messageText, maxLength) => {
+	const delimiter = '\n'
+	if (messageText.length > maxLength) {
+		messageText = messageText.substring(0, maxLength).split(delimiter)
+		// if no newlines, we don't remove anything, we keep the truncated message as is
+		if (messageText.length > 1) {
+			// remove all text after the last newline in the truncated message
+			// this avoids truncating in the middle of markdown
+			messageText.splice(-1, 1)
+		}
+		messageText = messageText.join(delimiter) + '*[...]*'
+	}
+	return messageText
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -997,6 +997,12 @@
 				"uri-js": "^4.2.2"
 			}
 		},
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+			"dev": true
+		},
 		"ansi-escapes": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -1279,6 +1285,12 @@
 					}
 				}
 			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
 		},
 		"btoa-lite": {
 			"version": "1.0.0",
@@ -2197,6 +2209,15 @@
 			"integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
 			"dev": true
 		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2276,6 +2297,12 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
 			"integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -2370,6 +2397,35 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.1.0",
+				"string.prototype.trimright": "^2.1.0"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"es6-promise": {
@@ -2940,6 +2996,23 @@
 				"resolve-dir": "^1.0.1"
 			}
 		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				}
+			}
+		},
 		"flat-cache": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -3281,6 +3354,12 @@
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -3333,6 +3412,12 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3364,6 +3449,12 @@
 					}
 				}
 			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -3718,6 +3809,12 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
 		"is-ci": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -3746,6 +3843,12 @@
 					}
 				}
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-decimal": {
 			"version": "1.0.3",
@@ -3888,6 +3991,15 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -3905,6 +4017,15 @@
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
 			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-text-path": {
 			"version": "1.0.1",
@@ -4680,6 +4801,200 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"mocha": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+			"integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.3.0",
+				"yargs-parser": "13.1.1",
+				"yargs-unparser": "1.6.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -4748,6 +5063,16 @@
 			"dev": true,
 			"requires": {
 				"lodash.toarray": "^4.4.0"
+			}
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+			"dev": true,
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
 			}
 		},
 		"node-fetch": {
@@ -8356,6 +8681,18 @@
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -8363,6 +8700,28 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.pick": {
@@ -9642,6 +10001,26 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -10161,6 +10540,15 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
 		"windows-release": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
@@ -10311,6 +10699,156 @@
 			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
+			}
+		},
+		"yargs-unparser": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+			"dev": true,
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.15",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"yup": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"commit": "git-cz",
 		"lint": "eslint lib index.js",
 		"prettier": "prettier --write --list-different '**/*.js?(on)'",
-		"semantic-release": "semantic-release"
+		"semantic-release": "semantic-release",
+		"test": "mocha"
 	},
 	"dependencies": {
 		"@semantic-release/error": "^2.2.0",
@@ -59,7 +60,8 @@
 		"husky": "^1.3.1",
 		"lint-staged": "^8.1.5",
 		"prettier": "^1.16.4",
-		"semantic-release": "^15.13.3"
+		"semantic-release": "^15.13.3",
+		"mocha": "^6.2.2"
 	},
 	"peerDependencies": {
 		"semantic-release": ">=11.0.0 <16.0.0"

--- a/test/test_truncate.js
+++ b/test/test_truncate.js
@@ -1,0 +1,22 @@
+const assert = require('assert')
+const truncate = require('../lib/truncate')
+
+describe('test truncate', () => {
+	it('should not truncate when length <= maxLength', () => {
+		const expected = 'hello world'
+		const actual = truncate(expected, expected.length)
+		assert.equal(expected, actual)
+	})
+
+	it('should not remove last element when no newline', () => {
+		const expected = 'hello wor*[...]*'
+		const actual = truncate('hello world and good morning', 9)
+		assert.equal(expected, actual)
+	})
+
+	it('should remove last element when newline', () => {
+		const expected = 'hello\nworld*[...]*'
+		const actual = truncate('hello\nworld\nand\ngood\nmorning', 14)
+		assert.equal(expected, actual)
+	})
+})


### PR DESCRIPTION
This tries to avoid most situations where the truncating of release notes happens in the middle of markdown, leading to output like this:
```
•   added file test03 (NNN-3003) (8bf6377)
•   added file test04 (NNN-3004) ([cb4f7de](https://github.com/user/testing-semantic-release/commit/cb4f7d​[...]​
```
We first truncate release notes on MAX length (currently 2900 characters). Then we split on newline ("\n") and remove the last element in the resulting array.

This would produce (using the above output):
```
•   added file test03 (NNN-3003) (8bf6377)
```