### PR TITLE
fix: Truncate release notes on "onSuccessTemplate"

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -25,21 +25,25 @@ module.exports = async (pluginConfig, context) => {
 
 	logger.log('Sending slack notification on success')
 
-	let slackMessage = {}
-
 	const repoPath =
 		options.repositoryUrl.indexOf('git@github.com') !== -1
 			? options.repositoryUrl.split(':')[1].replace('.git', '')
 			: undefined
 	const repoURL = repoPath && `https://github.com/${repoPath}`
 
+	let releaseNotes = nextRelease.notes
+
+	if (pluginConfig.markdownReleaseNotes) {
+		// Creating slack format from the markdown notes.
+		releaseNotes = slackifyMarkdown(releaseNotes)
+	}
+
+	// truncate long messages
+	releaseNotes = truncate(releaseNotes, MAX_LENGTH)
+
+	let slackMessage = {}
 	// Override default success message
 	if (pluginConfig.onSuccessTemplate) {
-		// Creating slack format from the markdown notes.
-		let releaseNotes = nextRelease.notes
-		if (pluginConfig.markdownReleaseNotes)
-			releaseNotes = slackifyMarkdown(releaseNotes)
-
 		slackMessage = template(pluginConfig.onSuccessTemplate, {
 			package_name,
 			npm_package_version: nextRelease.version,
@@ -60,18 +64,12 @@ module.exports = async (pluginConfig, context) => {
 			}
 		]
 
-		if (nextRelease.notes !== '') {
-			// truncate long messages
-			let messageText = truncate(nextRelease.notes, MAX_LENGTH)
-
-			if (pluginConfig.markdownReleaseNotes)
-				messageText = slackifyMarkdown(messageText)
-
+		if (releaseNotes !== '') {
 			messageBlocks.push({
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `${messageText}`
+					text: `${releaseNotes}`
 				}
 			})
 		}

--- a/test/test_truncate.js
+++ b/test/test_truncate.js
@@ -2,6 +2,12 @@ const assert = require('assert')
 const truncate = require('../lib/truncate')
 
 describe('test truncate', () => {
+	it('should not fail with empty message', () => {
+		const expected = ''
+		const actual = truncate(expected, expected.length)
+		assert.equal(expected, actual)
+	})
+
 	it('should not truncate when length <= maxLength', () => {
 		const expected = 'hello world'
 		const actual = truncate(expected, expected.length)


### PR DESCRIPTION
Question: In `onSuccessTemplate` is `true` path, message blocks are not used. Should they be?

Fixes: #21