### PR TITLE
feat: add maxLength option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ Alternatively, you could pass the webhook as a configuration option.
 
 ### Options
 
-| Option                 | Description                                                                                                                                                               | Default       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success.                                             | false         |
-| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.                                                    | false         |
-| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).                                              | undefined     |
-| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).                                                    | undefined     |
-| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                                                                  | false         |
-| `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                                                                       | SLACK_WEBHOOK |
-| `maxLength`            | Maximum character length for the release notes before truncation. [Slacks hard limit is 40,000](https://api.slack.com/changelog/2018-04-truncating-really-long-messages). | 2900          |
+| Option                 | Description                                                                                                                                                                                                                                     | Default       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success.                                                                                                                   | false         |
+| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.                                                                                                                          | false         |
+| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).                                                                                                                    | undefined     |
+| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).                                                                                                                          | undefined     |
+| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                                                                                                                                        | false         |
+| `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                                                                                                                                             | SLACK_WEBHOOK |
+| `unsafeMaxLength`      | Maximum character length for the release notes before truncation. If maxLength is too high, messages can be dropped. [Read here](https://github.com/juliuscc/semantic-release-slack-bot/issues/26#issuecomment-569804359) for more information. | 2900          |
 
 ### Templating
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 
 ```json
 {
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    [
-      "semantic-release-slack-bot",
-      {
-        "notifyOnSuccess": false,
-        "notifyOnFail": true
-      }
-    ]
-  ]
+	"plugins": [
+		"@semantic-release/commit-analyzer",
+		"@semantic-release/release-notes-generator",
+		[
+			"semantic-release-slack-bot",
+			{
+				"notifyOnSuccess": false,
+				"notifyOnFail": true
+			}
+		]
+	]
 }
 ```
 
@@ -80,14 +80,15 @@ Alternatively, you could pass the webhook as a configuration option.
 
 ### Options
 
-| Option                 | Description                                                                                                                   | Default       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success. | false         |
-| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.        | false         |
-| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).  | undefined     |
-| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).        | undefined     |
-| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                      | false         |
-| `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                           | SLACK_WEBHOOK |
+| Option                 | Description                                                                                                                                                               | Default       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `notifyOnSuccess`      | Determines if a succesfull release should trigger a slack message to be sent. If `false` this plugin does nothing on success.                                             | false         |
+| `notifyOnFail`         | Determines if a failed release should trigger a slack message to be sent. If `false` this plugin does nothing on fail.                                                    | false         |
+| `onSuccessTemplate`    | Provides a template for the slack message object on success when `notifyOnSuccess` is `true`. See [templating](#templating).                                              | undefined     |
+| `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).                                                    | undefined     |
+| `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                                                                  | false         |
+| `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                                                                       | SLACK_WEBHOOK |
+| `maxLength`            | Maximum character length for the release notes before truncation. [Slacks hard limit is 40,000](https://api.slack.com/changelog/2018-04-truncating-really-long-messages). | 2900          |
 
 ### Templating
 

--- a/lib/success.js
+++ b/lib/success.js
@@ -5,7 +5,7 @@ const template = require('./template')
 const truncate = require('./truncate')
 const getRepoInfo = require('./getRepoInfo')
 
-// Max lenght of message to the slack api is 3000 characters. Make sure we are below that.
+// Max length of message to the slack api is 40,000 characters. 2900 is based on the old limit.
 const MAX_LENGTH = 2900
 
 module.exports = async (pluginConfig, context) => {
@@ -15,7 +15,10 @@ module.exports = async (pluginConfig, context) => {
 		options,
 		env: { SEMANTIC_RELEASE_PACKAGE, npm_package_name }
 	} = context
-	const { slackWebhook = process.env.SLACK_WEBHOOK } = pluginConfig
+	const {
+		slackWebhook = process.env.SLACK_WEBHOOK,
+		maxLength = MAX_LENGTH
+	} = pluginConfig
 
 	const package_name = SEMANTIC_RELEASE_PACKAGE || npm_package_name
 
@@ -36,7 +39,7 @@ module.exports = async (pluginConfig, context) => {
 	}
 
 	// truncate long messages
-	releaseNotes = truncate(releaseNotes, MAX_LENGTH)
+	releaseNotes = truncate(releaseNotes, maxLength)
 
 	let slackMessage = {}
 	// Override default success message

--- a/lib/success.js
+++ b/lib/success.js
@@ -5,7 +5,7 @@ const template = require('./template')
 const truncate = require('./truncate')
 const getRepoInfo = require('./getRepoInfo')
 
-// Max length of message to the slack api is 40,000 characters. 2900 is based on the old limit.
+// 2900 is the limit for a message block of type 'section'.
 const MAX_LENGTH = 2900
 
 module.exports = async (pluginConfig, context) => {
@@ -17,7 +17,7 @@ module.exports = async (pluginConfig, context) => {
 	} = context
 	const {
 		slackWebhook = process.env.SLACK_WEBHOOK,
-		maxLength = MAX_LENGTH
+		unsafeMaxLength = MAX_LENGTH
 	} = pluginConfig
 
 	const package_name = SEMANTIC_RELEASE_PACKAGE || npm_package_name
@@ -39,7 +39,7 @@ module.exports = async (pluginConfig, context) => {
 	}
 
 	// truncate long messages
-	releaseNotes = truncate(releaseNotes, maxLength)
+	releaseNotes = truncate(releaseNotes, unsafeMaxLength)
 
 	let slackMessage = {}
 	// Override default success message


### PR DESCRIPTION
fixes: #26 

I feel leaving the 2900 limit as default is sensible, because most people will not need a massive limit, but the option allows them to increase it if necessary.