### PR TITLE
fix(getrepoinfo): fix for other TLD checking in repo url

### DIFF
--- a/lib/getRepoInfo.js
+++ b/lib/getRepoInfo.js
@@ -6,7 +6,10 @@ module.exports = repositoryUrl => {
   }
   const parsedUrl = new url.URL(
     // without these replacements we will get a TypeError [ERR_INVALID_URL]
-    repositoryUrl.replace('.com:', '.com/').replace('.org:', '.org/')
+    repositoryUrl.replace(
+      /\.([a-z])*:/i,
+      rep => rep.substring(0, rep.length - 1) + '/'
+    )
   )
   const path = parsedUrl.pathname
     .substring(1) // remove leading "/"

--- a/test/test_getRepoInfo.js
+++ b/test/test_getRepoInfo.js
@@ -43,4 +43,11 @@ describe('test getRepoInfo', () => {
     const expectedUrl = 'https://github.com/hello/world'
     runAssert(repositoryUrl, expectedPath, expectedUrl)
   })
+
+  it('should work for repo url with other TLD', () => {
+    const repositoryUrl = 'git@github.pl:hello/world.git'
+    const expectedPath = 'hello/world'
+    const expectedUrl = 'https://github.pl/hello/world'
+    runAssert(repositoryUrl, expectedPath, expectedUrl)
+  })
 })


### PR DESCRIPTION
Now plugin should work properly with private/internal repositories with other TLD than .com