### PR TITLE
Add packageName as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Alternatively, you could pass the webhook as a configuration option.
 | `onFailTemplate`       | Provides a template for the slack message object on fail when `notifyOnFail` is `true`. See [templating](#templating).                                                                                                                          | undefined     |
 | `markdownReleaseNotes` | Pass release notes through markdown to slack formatter before rendering.                                                                                                                                                                        | false         |
 | `slackWebhook`         | Slack webhook created when adding app to workspace.                                                                                                                                                                                             | SLACK_WEBHOOK |
+| `packageName `         | Override or add package name instead of npm package name                                                                                                                                                                                        | SEMANTIC_RELEASE_PACKAGE or npm package name |
 | `unsafeMaxLength`      | Maximum character length for the release notes before truncation. If maxLength is too high, messages can be dropped. [Read here](https://github.com/juliuscc/semantic-release-slack-bot/issues/26#issuecomment-569804359) for more information. | 2900          |
 
 ### Templating

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -9,12 +9,10 @@ module.exports = async (pluginConfig, context) => {
     errors,
     env: { SEMANTIC_RELEASE_PACKAGE, npm_package_name }
   } = context
-  const {
-    slackWebhook = process.env.SLACK_WEBHOOK,
-    packageName
-  } = pluginConfig
+  const { slackWebhook = process.env.SLACK_WEBHOOK, packageName } = pluginConfig
 
-  const package_name = SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
+  const package_name =
+    SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
 
   if (!pluginConfig.notifyOnFail) {
     logger.log('Notifying on fail skipped')

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -9,9 +9,12 @@ module.exports = async (pluginConfig, context) => {
     errors,
     env: { SEMANTIC_RELEASE_PACKAGE, npm_package_name }
   } = context
-  const { slackWebhook = process.env.SLACK_WEBHOOK } = pluginConfig
+  const {
+    slackWebhook = process.env.SLACK_WEBHOOK,
+    packageName
+  } = pluginConfig
 
-  const package_name = SEMANTIC_RELEASE_PACKAGE || npm_package_name
+  const package_name = SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
 
   if (!pluginConfig.notifyOnFail) {
     logger.log('Notifying on fail skipped')

--- a/lib/success.js
+++ b/lib/success.js
@@ -17,10 +17,11 @@ module.exports = async (pluginConfig, context) => {
   } = context
   const {
     slackWebhook = process.env.SLACK_WEBHOOK,
-    unsafeMaxLength = MAX_LENGTH
+    unsafeMaxLength = MAX_LENGTH,
+    packageName
   } = pluginConfig
 
-  const package_name = SEMANTIC_RELEASE_PACKAGE || npm_package_name
+  const package_name = SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
 
   if (!pluginConfig.notifyOnSuccess) {
     logger.log('Notifying on success skipped')

--- a/lib/success.js
+++ b/lib/success.js
@@ -21,7 +21,8 @@ module.exports = async (pluginConfig, context) => {
     packageName
   } = pluginConfig
 
-  const package_name = SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
+  const package_name =
+    SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
 
   if (!pluginConfig.notifyOnSuccess) {
     logger.log('Notifying on success skipped')

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -24,7 +24,7 @@ module.exports = (pluginConfig, context) => {
     throw new SemanticReleaseError(
       'No name for the package defined.',
       'ENOPACKAGENAME',
-      `A name for the package must be created. Run through npm (npm run <semantic-release-script> to use npm package name or define packageName in the pluigin config or \`SEMANTIC_RELEASE_PACKAGE\` in the environment`
+      `A name for the package must be created. Run through npm (npm run <semantic-release-script> to use npm package name or define packageName in the plugin config or \`SEMANTIC_RELEASE_PACKAGE\` in the environment`
     )
   }
 }

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -13,7 +13,11 @@ module.exports = (pluginConfig, context) => {
     )
   }
 
-  if (!context.env.npm_package_name && !pluginConfig.packageName && !context.env.SEMANTIC_RELEASE_PACKAGE) {
+  if (
+    !context.env.npm_package_name &&
+    !pluginConfig.packageName &&
+    !context.env.SEMANTIC_RELEASE_PACKAGE
+  ) {
     logger.log(
       'npm package name, config packageName and SEMANTIC_RELEASE_PACKAGE name are undefined'
     )

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -13,14 +13,14 @@ module.exports = (pluginConfig, context) => {
     )
   }
 
-  if (!context.env.npm_package_name && !context.env.SEMANTIC_RELEASE_PACKAGE) {
+  if (!context.env.npm_package_name && !pluginConfig.packageName && !context.env.SEMANTIC_RELEASE_PACKAGE) {
     logger.log(
-      'npm package name and SEMANTIC_RELEASE_PACKAGE name are undefined'
+      'npm package name, config packageName and SEMANTIC_RELEASE_PACKAGE name are undefined'
     )
     throw new SemanticReleaseError(
       'No name for the package defined.',
       'ENOPACKAGENAME',
-      `A name for the package must be created. Run through npm (npm run <semantic-release-script> to use npm package name or define \`SEMANTIC_RELEASE_PACKAGE\` in the environment`
+      `A name for the package must be created. Run through npm (npm run <semantic-release-script> to use npm package name or define packageName in the pluigin config or \`SEMANTIC_RELEASE_PACKAGE\` in the environment`
     )
   }
 }


### PR DESCRIPTION
This PR adds the option `packageName` to the plugin configuration.

In a non-node project, `SEMANTIC_RELEASE_PACKAGE` is the only environment variable that needs setting to use this plugin. Adding this option allows a user to configure semantic-release-slack-bot entirely in their semantic-release config file.