### PR TITLE
feat: add support for token/channel option

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -2,6 +2,7 @@
 const getConfigToUse = require('./getConfigToUse')
 const postMessage = require('./postMessage')
 const template = require('./template')
+const getSlackVars = require('./getSlackVars')
 
 module.exports = async (pluginConfig, context) => {
   const {
@@ -12,7 +13,8 @@ module.exports = async (pluginConfig, context) => {
   } = context
 
   const configToUse = getConfigToUse(pluginConfig, context)
-  const { slackWebhook = process.env.SLACK_WEBHOOK, packageName } = configToUse
+  const { packageName } = configToUse
+  const { slackWebhook, slackToken, slackChannel } = getSlackVars(configToUse)
 
   const package_name =
     SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
@@ -112,5 +114,9 @@ module.exports = async (pluginConfig, context) => {
     }
   }
 
-  await postMessage(slackMessage, logger, slackWebhook)
+  await postMessage(slackMessage, logger, {
+    slackWebhook,
+    slackChannel,
+    slackToken
+  })
 }

--- a/lib/getSlackVars.js
+++ b/lib/getSlackVars.js
@@ -1,0 +1,18 @@
+module.exports = config => {
+  const {
+    slackWebhookEnVar = 'SLACK_WEBHOOK',
+    slackWebhook = process.env[slackWebhookEnVar],
+    slackTokenEnVar = 'SLACK_TOKEN',
+    slackToken = process.env[slackTokenEnVar],
+    slackChannelEnVar = 'SLACK_CHANNEL',
+    slackChannel = process.env[slackChannelEnVar]
+  } = config
+  return {
+    slackWebhookEnVar,
+    slackWebhook,
+    slackChannelEnVar,
+    slackChannel,
+    slackTokenEnVar,
+    slackToken
+  }
+}

--- a/lib/postMessage.js
+++ b/lib/postMessage.js
@@ -1,17 +1,33 @@
 const fetch = require('node-fetch')
 const SemanticReleaseError = require('@semantic-release/error')
 
-module.exports = async (message, logger, slackWebhook) => {
+module.exports = async (
+  message,
+  logger,
+  { slackWebhook, slackToken, slackChannel }
+) => {
   let response
   let bodyText
   try {
-    response = await fetch(slackWebhook, {
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(message)
-    })
+    if (slackToken && slackChannel) {
+      message.channel = slackChannel
+      response = await fetch('https://slack.com/api/chat.postMessage', {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: slackToken
+        },
+        body: JSON.stringify(message)
+      })
+    } else {
+      response = await fetch(slackWebhook, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(message)
+      })
+    }
     bodyText = await response.text()
   } catch (e) {
     throw new SemanticReleaseError(e.message, 'SLACK CONNECTION FAILED')

--- a/lib/success.js
+++ b/lib/success.js
@@ -5,6 +5,7 @@ const template = require('./template')
 const truncate = require('./truncate')
 const getRepoInfo = require('./getRepoInfo')
 const getConfigToUse = require('./getConfigToUse')
+const getSlackVars = require('./getSlackVars')
 
 // 2900 is the limit for a message block of type 'section'.
 const MAX_LENGTH = 2900
@@ -18,12 +19,8 @@ module.exports = async (pluginConfig, context) => {
   } = context
 
   const configToUse = getConfigToUse(pluginConfig, context)
-  const {
-    slackWebhookEnVar = 'SLACK_WEBHOOK',
-    slackWebhook = process.env[slackWebhookEnVar],
-    unsafeMaxLength = MAX_LENGTH,
-    packageName
-  } = configToUse
+  const { unsafeMaxLength = MAX_LENGTH, packageName } = configToUse
+  const { slackWebhook, slackToken, slackChannel } = getSlackVars(configToUse)
 
   const package_name =
     SEMANTIC_RELEASE_PACKAGE || packageName || npm_package_name
@@ -113,5 +110,9 @@ module.exports = async (pluginConfig, context) => {
     }
   }
 
-  await postMessage(slackMessage, logger, slackWebhook)
+  await postMessage(slackMessage, logger, {
+    slackWebhook,
+    slackChannel,
+    slackToken
+  })
 }

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -1,13 +1,38 @@
 const SemanticReleaseError = require('@semantic-release/error')
+const getSlackVars = require('./getSlackVars')
 
 module.exports = (pluginConfig, context) => {
   const { logger } = context
   const {
-    slackWebhookEnVar = 'SLACK_WEBHOOK',
-    slackWebhook = process.env[slackWebhookEnVar]
-  } = pluginConfig
+    slackWebhook,
+    slackWebhookEnVar,
+    slackToken,
+    slackTokenEnVar,
+    slackChannel,
+    slackChannelEnVar
+  } = getSlackVars(pluginConfig)
 
-  if (!slackWebhook) {
+  if (slackChannel || slackToken) {
+    if (!slackToken) {
+      logger.log(
+        'SLACK_CHANNEL must be used with SLACK_TOKEN which has not been defined.'
+      )
+      throw new SemanticReleaseError(
+        'No Slack token defined.',
+        'ENOSLACKTOKEN',
+        `A Slack Token must be created and set in the \`${slackTokenEnVar}\` environment variable on your CI environment.\n\n\nPlease make sure to create a Slack Token and to set it in the \`${slackTokenEnVar}\` environment variable on your CI environment. Alternatively, provide \`slackToken\` as a configuration option.`
+      )
+    } else if (!slackChannel) {
+      logger.log(
+        'SLACK_TOKEN must be used with SLACK_CHANNEL which has not been defined.'
+      )
+      throw new SemanticReleaseError(
+        'No Slack channel defined.',
+        'ENOSLACKCHANNEL',
+        `A Slack Channel must be created and set in the \`${slackChannelEnVar}\` environment variable on your CI environment.\n\n\nPlease make sure to set a Slack Channel in the \`${slackChannelEnVar}\` environment variable on your CI environment. Alternatively, provide \`slackChannel\` as a configuration option.`
+      )
+    }
+  } else if (!slackWebhook) {
     logger.log('SLACK_WEBHOOK has not been defined.')
     throw new SemanticReleaseError(
       'No Slack web-hook defined.',

--- a/test/postMessage.test.js
+++ b/test/postMessage.test.js
@@ -4,18 +4,32 @@ const postMessage = require('../lib/postMessage')
 const SemanticReleaseError = require('@semantic-release/error')
 
 const slackWebhook = 'https://www.webhook.com'
+const slackPostMessageDomain = 'https://slack.com'
+const slackPostMessagePath = '/api/chat.postMessage'
+const slackToken = 'token'
+const slackChannel = 'channel'
 
-async function post(url) {
+async function postWebhook(url) {
   url = url || slackWebhook
-  await postMessage('message', { log: () => undefined }, url)
+  await postMessage('message', { log: () => undefined }, { slackWebhook: url })
 }
 
-describe('test postMessage', () => {
+async function postToken(token, channel) {
+  token = token || slackToken
+  channel = channel || slackChannel
+  await postMessage(
+    { text: 'message' },
+    { log: () => undefined },
+    { slackToken: token, slackChannel: channel }
+  )
+}
+
+describe('test postMessage with webhook', () => {
   it('should pass if response is 200 "ok"', async () => {
     nock(slackWebhook)
       .post('/')
       .reply(200, 'ok')
-    assert.ifError(await post())
+    assert.ifError(await postWebhook())
   })
 
   it('should fail if response text is not "ok"', async () => {
@@ -24,7 +38,7 @@ describe('test postMessage', () => {
       .post('/')
       .reply(200, response)
     await assert.rejects(
-      post(),
+      postWebhook(),
       new SemanticReleaseError(response, 'INVALID SLACK COMMAND')
     )
   })
@@ -35,19 +49,50 @@ describe('test postMessage', () => {
       .post('/')
       .reply(500, response)
     await assert.rejects(
-      post(),
+      postWebhook(),
       new SemanticReleaseError(response, 'INVALID SLACK COMMAND')
     )
   })
 
   it('should fail if incorrect url', async () => {
     const incorrectUrl = 'https://sekhfskdfdjksfkjdhfsd.com'
-    await assert.rejects(post(incorrectUrl), {
+    await assert.rejects(postWebhook(incorrectUrl), {
       name: 'SemanticReleaseError',
       code: 'SLACK CONNECTION FAILED',
       details: undefined,
       message: /ENOTFOUND/,
       semanticRelease: true
     })
+  })
+})
+
+describe('test postMessage with token/channel', () => {
+  it('should pass if response is 200 "ok"', async () => {
+    nock(slackPostMessageDomain)
+      .post(slackPostMessagePath)
+      .reply(200, 'ok')
+    assert.ifError(await postToken())
+  })
+
+  it('should fail if response text is not "ok"', async () => {
+    const response = 'not ok'
+    nock(slackPostMessageDomain)
+      .post(slackPostMessagePath)
+      .reply(200, response)
+    await assert.rejects(
+      postToken(),
+      new SemanticReleaseError(response, 'INVALID SLACK COMMAND')
+    )
+  })
+
+  it('should fail if response status code is not 200', async () => {
+    const response = 'error message'
+    nock(slackPostMessageDomain)
+      .post(slackPostMessagePath)
+      .reply(500, response)
+    await assert.rejects(
+      postToken(),
+      new SemanticReleaseError(response, 'INVALID SLACK COMMAND')
+    )
   })
 })

--- a/test/verifyConditions.test.js
+++ b/test/verifyConditions.test.js
@@ -7,10 +7,18 @@ const { getContext } = require('./testUtils')
 describe('test verifyConditions', () => {
   beforeEach(() => {
     delete process.env.SLACK_WEBHOOK
+    delete process.env.SLACK_TOKEN
+    delete process.env.SLACK_CHANNEL
+    delete process.env.CUSTOM_VAR
+    delete process.env.CUSTOM_WEBHOOK
   })
 
   describe('test slack webhooks options', () => {
-    const fakeContext = { logger: { log: () => undefined }, env: {} }
+    const fakeContext = {
+      ...getContext(),
+      logger: { log: () => undefined },
+      env: {}
+    }
     const defaultPluginConfig = { packageName: 'test' }
     const getMissingWebhookError = slackWebhookEnVar => {
       return `A Slack Webhook must be created and set in the \`${slackWebhookEnVar}\` environment variable on your CI environment.\n\n\nPlease make sure to create a Slack Webhook and to set it in the \`${slackWebhookEnVar}\` environment variable on your CI environment. Alternatively, provide \`slackWebhook\` as a configuration option.`
@@ -58,6 +66,118 @@ describe('test verifyConditions', () => {
       process.env.CUSTOM_WEBHOOK = 'MY SLACK WEBHOOK'
       verifyConditions(
         { ...defaultPluginConfig, slackWebhookEnVar: 'CUSTOM_WEBHOOK' },
+        fakeContext
+      )
+    })
+  })
+
+  describe('test slack token and channel options', () => {
+    const fakeContext = {
+      ...getContext(),
+      logger: { log: () => undefined },
+      env: {}
+    }
+    const defaultPluginConfig = { packageName: 'test' }
+    const getMissingTokenError = slackTokenEnVar => {
+      return `A Slack Token must be created and set in the \`${slackTokenEnVar}\` environment variable on your CI environment.\n\n\nPlease make sure to create a Slack Token and to set it in the \`${slackTokenEnVar}\` environment variable on your CI environment. Alternatively, provide \`slackToken\` as a configuration option.`
+    }
+    const getMissingChannelError = slackChannelEnVar => {
+      return `A Slack Channel must be created and set in the \`${slackChannelEnVar}\` environment variable on your CI environment.\n\n\nPlease make sure to set a Slack Channel in the \`${slackChannelEnVar}\` environment variable on your CI environment. Alternatively, provide \`slackChannel\` as a configuration option.`
+    }
+
+    it('should throw if neither slackToken and environment variable SLACK_TOKEN are set but slackChannel is', () => {
+      assert.throws(
+        () =>
+          verifyConditions(
+            { ...defaultPluginConfig, slackChannel: 'some channel' },
+            fakeContext
+          ),
+        new SemanticReleaseError(
+          'No Slack token defined.',
+          'ENOSLACKTOKEN',
+          getMissingTokenError('SLACK_TOKEN')
+        )
+      )
+    })
+
+    it('should throw if slackChannel is set, slackToken is not set and slackTokenEnVar give an empty environment variable', () => {
+      assert.throws(
+        () =>
+          verifyConditions(
+            {
+              ...defaultPluginConfig,
+              slackChannel: 'some channel',
+              slackTokenEnVar: 'CUSTOM_TOKEN'
+            },
+            fakeContext
+          ),
+        new SemanticReleaseError(
+          'No Slack token defined.',
+          'ENOSLACKTOKEN',
+          getMissingTokenError('CUSTOM_TOKEN')
+        )
+      )
+    })
+
+    it('should throw if neither slackChannel and environment variable SLACK_CHANNEL are set but slackToken is', () => {
+      assert.throws(
+        () =>
+          verifyConditions(
+            { ...defaultPluginConfig, slackToken: 'some token' },
+            fakeContext
+          ),
+        new SemanticReleaseError(
+          'No Slack channel defined.',
+          'ENOSLACKCHANNEL',
+          getMissingChannelError('SLACK_CHANNEL')
+        )
+      )
+    })
+
+    it('should throw if slackToken is set, slackChannel is not set and slackChannelEnVar give an empty environment variable', () => {
+      assert.throws(
+        () =>
+          verifyConditions(
+            {
+              ...defaultPluginConfig,
+              slackToken: 'some token',
+              slackChannelEnVar: 'CUSTOM_CHANNEL'
+            },
+            fakeContext
+          ),
+        new SemanticReleaseError(
+          'No Slack channel defined.',
+          'ENOSLACKCHANNEL',
+          getMissingChannelError('CUSTOM_CHANNEL')
+        )
+      )
+    })
+
+    it('should not throw if slackToken and slackChannel is provided', () => {
+      verifyConditions(
+        {
+          ...defaultPluginConfig,
+          slackToken: 'MY SLACK TOKEN',
+          slackChannel: 'MY SLACK CHANNEL'
+        },
+        fakeContext
+      )
+    })
+
+    it('should not throw if SLACK_TOKEN and SLACK_CHANNEL is set', () => {
+      process.env.SLACK_TOKEN = 'MY SLACK TOKEN'
+      process.env.SLACK_CHANNEL = 'MY SLACK CHANNEL'
+      verifyConditions(defaultPluginConfig, fakeContext)
+    })
+
+    it('should not throw if slackTokenEnVar and slackChannelEnVar give an environment variable', () => {
+      process.env.CUSTOM_VAR = 'some var'
+      verifyConditions(
+        {
+          ...defaultPluginConfig,
+          slackTokenEnVar: 'CUSTOM_VAR',
+          slackChannelEnVar: 'CUSTOM_VAR'
+        },
         fakeContext
       )
     })


### PR DESCRIPTION
Supporting alternative to the webhook url that makes use of a channel name and oauth token

fix #73