### PR TITLE
fix: slack token missing bearer prefix

### DIFF
--- a/lib/postMessage.js
+++ b/lib/postMessage.js
@@ -24,7 +24,7 @@ module.exports = async (
         method: 'post',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: slackToken
+          Authorization: `Bearer ${slackToken}`
         },
         body: JSON.stringify(message)
       })


### PR DESCRIPTION
Authorization failed due to incorrectly formatted header. Documentation reference: https://api.slack.com/web#slack-web-api__basics__post-bodies__json-encoded-bodies