### PR TITLE
fix: slackToken based message returns a JSON object

### DIFF
--- a/lib/postMessage.js
+++ b/lib/postMessage.js
@@ -8,6 +8,7 @@ module.exports = async (
 ) => {
   let response
   let bodyText
+  let isSuccess
   try {
     if (slackIcon) {
       const hasSemicolons = slackIcon.startsWith(':') && slackIcon.endsWith(':')
@@ -23,11 +24,13 @@ module.exports = async (
       response = await fetch('https://slack.com/api/chat.postMessage', {
         method: 'post',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/json; charset=utf-8',
           Authorization: `Bearer ${slackToken}`
         },
         body: JSON.stringify(message)
       })
+      bodyText = await response.text()
+      isSuccess = response.ok && JSON.parse(bodyText).ok
     } else {
       if (slackChannel) {
         message.channel = slackChannel
@@ -39,13 +42,14 @@ module.exports = async (
         },
         body: JSON.stringify(message)
       })
+      bodyText = await response.text()
+      isSuccess = response.ok && bodyText === 'ok'
     }
-    bodyText = await response.text()
   } catch (e) {
     throw new SemanticReleaseError(e.message, 'SLACK CONNECTION FAILED')
   }
 
-  if (!response.ok || bodyText !== 'ok') {
+  if (!isSuccess) {
     logger.log('JSON message format invalid: ' + bodyText)
     throw new SemanticReleaseError(bodyText, 'INVALID SLACK COMMAND')
   }


### PR DESCRIPTION
This correctly handles the return type of the chat.postMessage fetch request. This also means that "success" for the two methods of sending a slack message needs to be handled differently.

Here's the output I received on our CI when using channel/token option. This shouldn't affect anyone except the auth-token users, and then it's only the fail/success reporting in semantic-release that is affected. The slack message and version were correctly published/sent.

```
[6:49:29 AM] [semantic-release] [semantic-release-slack-bot] › ℹ  Sending slack notification on success 00:10
245[6:49:29 AM] [semantic-release] [semantic-release-slack-bot] › ℹ  JSON message format invalid: {"ok":true,"channel":"CCDGC2QPM","ts":"1642747769.000200","message":{"bot_id":"B02TGERD0R0","type":"message","text":"A new version of @tablecheck\/i18n has been released!","user":"U02T1RTQC5D","ts":"1642747769.000200","team":"T0794N43Z","bot_profile":{"id":"B02TGERD0R0","app_id":"A02TG8496EP","name":"TableCheck - Slack Integration","icons":{"image_36":"https:\/\/a.slack-edge.com\/80588\/img\/plugins\/app\/bot_36.png","image_48":"https:\/\/a.slack-edge.com\/80588\/img\/plugins\/app\/bot_48.png","image_72":"https:\/\/a.slack-edge.com\/80588\/img\/plugins\/app\/service_72.png"},"deleted":false,"updated":1641891948,"team_id":"T0794N43Z"},"attachments":[{"id":1,"blocks":[{"type":"context","block_id":"Rnigs","elements":[{"type":"mrkdwn","text":":package: *<https:\/\/github.com\/tablecheck\/js-i18n|tablecheck\/js-i18n>:*   <https:\/\/github.com\/tablecheck\/js-i18n\/releases\/tag\/v1.0.1|v1.0.1>","verbatim":false}]}],"color":"#2cbe4e","fallback":"[no preview available]"}],"blocks":[{"type":"section","block_id":"nfQAL","text":{"type":"mrkdwn","text":"A new version of `@tablecheck\/i18n` has been released!\nCurrent version is *#1.0.1*","verbatim":false}},{"type":"section","block_id":"+U5+g","text":{"type":"mrkdwn","text":"*<https:\/\/github.com\/tablecheck\/js-i18n\/compare\/v1.0.0...v1.0.1|1.0.1> (2022-01-21)*\n","verbatim":false}}]},"warning":"missing_charset","response_metadata":{"warnings":["missing_charset"]}} 00:10
246[6:49:29 AM] [semantic-release] › ✖  Failed step "success" of plugin "semantic-release-slack-bot"
```