### PR TITLE
fix: remove hashtag from version number

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -70,7 +70,7 @@ module.exports = async (pluginConfig, context) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `A new version of \`${package_name}\` has been released!\nCurrent version is *#${
+          text: `A new version of \`${package_name}\` has been released!\nCurrent version is *${
             nextRelease.version
           }*`
         }


### PR DESCRIPTION
This is to avoid markdown issues with Slack trying to show the version number as if it was a channel.

Fixes: #93