### PR TITLE
docs(slackChannel):  missing # in slackChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
         "notifyOnSuccess": false,
         "notifyOnFail": false,
         "slackToken": "token",
-        "slackChannel": "my-channel-name",
+        "slackChannel": "#my-channel-name",
         "branchesConfig": [
           {
             "pattern": "lts/*",


### PR DESCRIPTION
slackChannel has to be provided a correct channel name, ie. `#some-channel` to make it work.