### PR TITLE
fix: use package_name on fail message

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -53,7 +53,7 @@ module.exports = async (pluginConfig, context) => {
 
     const messageSummaryLine = `${
       plural ? 'Errors' : 'An error'
-    } occurred while trying to publish the new version of \`${npm_package_name}\`!`
+    } occurred while trying to publish the new version of \`${package_name}\`!`
 
     const divider = {
       type: 'divider'


### PR DESCRIPTION
Every time our semantic-release process failed in post in an slack channel the following message:

> An error occurred while trying to publish the new version of `undefined`!

This PR solves it by using the `package_name` variable instead.