### PR TITLE
fix: fix gitlab release url

### DIFF
--- a/lib/success.js
+++ b/lib/success.js
@@ -92,9 +92,9 @@ module.exports = async (pluginConfig, context) => {
 
     if (repo.path) {
       const gitTag = nextRelease.gitTag
-      const gitTagPrefix = repo.hostname.startsWith('gitlab')
-        ? '/-/releases/'
-        : '/releases/tag/'
+      const gitTagPrefix = repo.hostname.startsWith('github')
+        ? '/releases/tag/'
+        : '/-/releases/'
       const gitTagUrl = repo.URL + gitTagPrefix + gitTag
 
       slackMessage.attachments = [


### PR DESCRIPTION
Since github.com does not support selfhosted instances, it should be safe to invert gitlab check