### PR TITLE
feat: allow onSuccessFunction/onFailFunction to be a promise

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -41,7 +41,9 @@ module.exports = async (pluginConfig, context) => {
 
   // Override default fail message
   if (configToUse.onFailFunction) {
-    slackMessage = configToUse.onFailFunction(configToUse, context)
+    slackMessage = await Promise.resolve(
+      configToUse.onFailFunction(configToUse, context)
+    )
   } else if (configToUse.onFailTemplate) {
     slackMessage = template(configToUse.onFailTemplate, {
       package_name,

--- a/lib/success.js
+++ b/lib/success.js
@@ -55,7 +55,9 @@ module.exports = async (pluginConfig, context) => {
   let slackMessage = {}
   // Override default success message
   if (configToUse.onSuccessFunction) {
-    slackMessage = configToUse.onSuccessFunction(configToUse, context)
+    slackMessage = await Promise.resolve(
+      configToUse.onSuccessFunction(configToUse, context)
+    )
   } else if (configToUse.onSuccessTemplate) {
     slackMessage = template(configToUse.onSuccessTemplate, {
       package_name,


### PR DESCRIPTION
Hi,

Thanks for a great SR plug-in 🙏 

It is seeing heavy usage in a corporate environment I work in, where I also ran into the issue that I'd like to asynchronously build the template using [this library](https://github.com/tryfabric/mack). However if for instance `onSuccessFunction` is a Promise, the `slackMessage` isn't awaited, resulting in a `Promise { <pending> }` being offered to the Slack API and of course this results in `SemanticReleaseError: invalid_payload`.

`await Promise.resolve()` wrappers for both `onSuccessFunction` & `onFailFunction` should allow us to input both Promises and sync functions.

If you have any thoughts please let me know!